### PR TITLE
Loosen chai-spies version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
 
   "peerDependencies": {
-    "chai-spies": "0.6.0",
+    "chai-spies": "*",
     "karma-chai": "*"
   },
 


### PR DESCRIPTION
This changes the version requirement for `chai-spies` to `*` - as `karma-chai` is already `*` it seems pretty fitting to do this.
