### PR TITLE
Improve file path detection for chai-spies

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var path = require('path');
 
 var framework = function(files) {
     files.unshift({
-        pattern: path.resolve(require.resolve('chai-spies')).replace(/[^\/\\]*$/, 'chai-spies.js'),
+        pattern: require.resolve('chai-spies/chai-spies'),
         included: true,
         served: true,
         watched: false


### PR DESCRIPTION
This changes the previous RegEx replacement to instead use Node's require pattern to correctly find the chai-spies.js file. `path.resolve` has also been removed as `require.resolve` always returns an absolute path.
